### PR TITLE
fix - more option click propagation

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "next": "13.5.4",
     "react": "^18",
     "react-day-picker": "^8.8.2",
+    "react-device-detect": "^2.2.3",
     "react-dom": "^18",
     "react-hook-form": "^7.47.0",
     "react-redux": "^8.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ dependencies:
   react-day-picker:
     specifier: ^8.8.2
     version: 8.8.2(date-fns@2.30.0)(react@18.2.0)
+  react-device-detect:
+    specifier: ^2.2.3
+    version: 2.2.3(react-dom@18.2.0)(react@18.2.0)
   react-dom:
     specifier: ^18
     version: 18.2.0(react@18.2.0)
@@ -3461,6 +3464,17 @@ packages:
       react: 18.2.0
     dev: false
 
+  /react-device-detect@2.2.3(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==}
+    peerDependencies:
+      react: '>= 0.14.0'
+      react-dom: '>= 0.14.0'
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      ua-parser-js: 1.0.36
+    dev: false
+
   /react-dom@18.2.0(react@18.2.0):
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
     peerDependencies:
@@ -4113,6 +4127,10 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
+
+  /ua-parser-js@1.0.36:
+    resolution: {integrity: sha512-znuyCIXzl8ciS3+y3fHJI/2OhQIXbXw9MWC/o3qwyR+RGppjZHrM27CGFSKCJXi2Kctiz537iOu2KnXs1lMQhw==}
+    dev: false
 
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}

--- a/src/components/Folders.tsx
+++ b/src/components/Folders.tsx
@@ -6,6 +6,7 @@ import { Button } from "./ui/button";
 import { useRouter } from "next/navigation";
 import Icon from "./Icon";
 import FileFolderMoreOption from "./FileFolderMoreOption";
+import { isMobile } from "react-device-detect";
 
 const Folders = ({ data }: { data: TFolders }) => {
   const router = useRouter();
@@ -24,8 +25,12 @@ const Folders = ({ data }: { data: TFolders }) => {
             key={folder.$id}
             size={"lg"}
             className="max-sm:w-full max-sm:h-32 max-sm:p-4 flex-wrap sm:px-4"
-            onDoubleClick={() => handleFolderClick(folder.$id)}
-            onTouchEnd={() => handleFolderClick(folder.$id)}
+            onDoubleClick={() => {
+              if (!isMobile) handleFolderClick(folder.$id);
+            }}
+            onClick={() => {
+              if (isMobile) handleFolderClick(folder.$id);
+            }}
           >
             <span className="sm:mr-2 max-sm:w-full max-sm:h-16 block">
               <Icon


### PR DESCRIPTION
## Fixed option click propagation

### previous behavior

There was a problem in mobile devices when user click on more option in folder the folder touch event was triggered

### Current behavior

Now added a package react-device-detect and conditionally trigger click event of more option 